### PR TITLE
allow alternate prefix for puzzle_hash_to_address

### DIFF
--- a/chia-utils.js
+++ b/chia-utils.js
@@ -10068,11 +10068,11 @@
         return "0x" + bytes_to_hex(decode_puzzle_hash(address));
     }
 
-    function puzzle_hash_to_address(puzzle_hash) {
+    function puzzle_hash_to_address(puzzle_hash, prefix = "xch") {
         if(puzzle_hash.indexOf("0x") == 0) {
             puzzle_hash = puzzle_hash.substring(2);
         }
-        return encode_puzzle_hash(hex_to_bytes(puzzle_hash), "xch");
+        return encode_puzzle_hash(hex_to_bytes(puzzle_hash), prefix);
     }
 
     function get_coin_info(parent_coin_info, puzzle_hash, amount_decimal) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "chia-utils",
       "version": "1.0.9",
       "license": "AGPL-3.0-or-later",
       "devDependencies": {
@@ -160,7 +161,6 @@
       "dependencies": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
-        "fsevents": "~2.3.1",
         "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",

--- a/test/tester.js
+++ b/test/tester.js
@@ -40,4 +40,10 @@ describe("Test", function() {
 		}
 		assert.equal(equal, true);
 	});
+
+	it("6: Should convert a puzzle hash to an address with a non-defaul prefix", function() {
+		let puzzle_hash = "0xd730a0407dfcf4a2c6099b6aed6423a3fe2fe3469f538795f785ff6d594be0dd";
+		let expected = "txch16uc2qsraln6293sfnd4w6epr50lzlc6xnafc090hshlk6k2turwsa7px9x";
+		assert.equal(puzzle_hash_to_address(puzzle_hash, "txch"), expected)
+	});
 });

--- a/test/tester.js
+++ b/test/tester.js
@@ -41,7 +41,7 @@ describe("Test", function() {
 		assert.equal(equal, true);
 	});
 
-	it("6: Should convert a puzzle hash to an address with a non-defaul prefix", function() {
+	it("6: Should convert a puzzle hash to an address with a non-default prefix", function() {
 		let puzzle_hash = "0xd730a0407dfcf4a2c6099b6aed6423a3fe2fe3469f538795f785ff6d594be0dd";
 		let expected = "txch16uc2qsraln6293sfnd4w6epr50lzlc6xnafc090hshlk6k2turwsa7px9x";
 		assert.equal(puzzle_hash_to_address(puzzle_hash, "txch"), expected)


### PR DESCRIPTION
In order to work in testnet this code needs to accept an address prefix other than "xch".

Add prefix as a parameter to `puzzle_hash_to_address`. Defaults to "xch" to be non-breaking.

Test included,